### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,4 +26,4 @@ services:
        WORDPRESS_DB_USER: wordpress
        WORDPRESS_DB_PASSWORD: wordpress
 volumes:
-    dbdata
+    dbdata:


### PR DESCRIPTION
Produces ERROR: In file './docker-compose.yml', volume must be a mapping not a string.
To fix that, a semicolon in the last line is required.